### PR TITLE
0.8.1 - Add 'before' and 'after' options to XPath fetch

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,6 @@
 O.8.0  2016-01-12
   - Fetch data in bulk where possible
+  - Add 'before' and 'after' options to XPath-finder
 
 0.7.2  2015-12-31
   - Add some Scraper helper functions in EveryPolitician::Wikidata

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -27,8 +27,19 @@ module EveryPolitician
     require 'pry'
     def self.wikipedia_xpath(h)
       noko = self.noko_for(URI.decode h[:url])
-      binding.pry if h[:debug] == true
+
+      if h[:after]
+        point = noko.xpath(h[:after]) or raise "Can't find #{h[:after]}"
+        point.xpath('.//preceding::*').remove 
+      end
+
+      if h[:before]
+        point = noko.xpath(h[:before]) or raise "Can't find #{h[:before]}"
+        point.xpath('.//following::*').remove 
+      end
+
       names = noko.xpath(h[:xpath]).map(&:text).uniq
+      binding.pry if h[:debug] == true
       raise "No names found in #{h[:url]}" if names.count.zero?
       return names
     end

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = "0.8.0"
+    VERSION = "0.8.1"
   end
 end


### PR DESCRIPTION
Only find things matching the XPath expression before and after these