### PR TITLE
0.8.2 error if 'before' or 'after' return nothing

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -29,12 +29,14 @@ module EveryPolitician
       noko = self.noko_for(URI.decode h[:url])
 
       if h[:after]
-        point = noko.xpath(h[:after]) or raise "Can't find #{h[:after]}"
+        point = noko.xpath(h[:after]) 
+        raise "Can't find #{h[:after]}" if point.empty?
         point.xpath('.//preceding::*').remove 
       end
 
       if h[:before]
-        point = noko.xpath(h[:before]) or raise "Can't find #{h[:before]}"
+        point = noko.xpath(h[:before]) 
+        raise "Can't find #{h[:before]}" if point.empty?
         point.xpath('.//following::*').remove 
       end
 

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = "0.8.1"
+    VERSION = "0.8.2"
   end
 end


### PR DESCRIPTION
A failing XPath will return an empty list, so error in those cases.