### PR TITLE
Add a `batch_size` option

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+O.12.0  2016-03-25
+  - Add a `batch_size` option
+
 O.11.0  2016-03-25
   - Move the list of want/skip properties to external file
 

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = "0.11.0"
+    VERSION = "0.12.0"
   end
 end


### PR DESCRIPTION
Rather than the scraper files doing their own slicing, allow a batch_size
option to look up the items in groups, rather than all at once (e.g. to save memory)