### PR TITLE
0.13 Warn about missing Wikidata IDs

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+O.13.0  2016-03-26
+  - Report on missing Wikidata IDs
+  - Add a `last_seen` column
+
 O.12.0  2016-03-25
   - Add a `batch_size` option
 

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -81,6 +81,7 @@ module EveryPolitician
             next
           end
           data[:original_wikiname] = name
+          data[:last_seen] = Date.today.to_s
           puts data if h[:output] == true
           ScraperWiki.save_sqlite([:id], data)
         end

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -121,7 +121,10 @@ class WikiData
         [ redirected_from[p.last['title']] || p.last['title'], p.last['pageprops']['wikibase_item'] ]
       }
     }
-    Hash[ res.flatten(1) ]
+    results = Hash[ res.flatten(1) ]
+    missing = titles - results.keys
+    warn "Can't find Wikidata IDs for: #{missing.join(", ")} in #{lang}" if missing.any?
+    return results
   end
   
   class Category < WikiData

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = "0.12.0"
+    VERSION = "0.13.0"
   end
 end


### PR DESCRIPTION
Report on any pages what don't have associated Wikidata IDs (e.g. because
the Wikipedia page was created after the last time the auto-importer to
Wikidata was run)