### PR TITLE
Clean out existing data before rescraping

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+O.15.0  2016-06-05
+  - Delete existing data before re-scraping
+
 O.14.0  2016-03-27
   - Add a `subcategories` method on Category
   - Move the `last_seen` to a different table

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = "0.14.0"
+    VERSION = "0.15.0"
   end
 end


### PR DESCRIPTION
This should make renamings etc much more obvious more quickly.