### PR TITLE
0.17.0 Optionally specify a Morph table

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,8 @@
-O.15.0  2016-06-14
+O.17.0  2016-06-17
+  - Can now specify an optional `table` parameter when fetching data
+    from a Morph scraper
+
+O.16.0  2016-06-14
   - Better handling of errors from Wikisnakker
 
 O.15.0  2016-06-05

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -27,7 +27,7 @@ module EveryPolitician
       morph_api_key = ENV["MORPH_API_KEY"]
       result = RestClient.get morph_api_url, params: {
         key: morph_api_key,
-        query: "SELECT DISTINCT(#{h[:column]}) AS wikiname FROM data"
+        query: "SELECT DISTINCT(#{h[:column]}) AS wikiname FROM #{h[:table] || data}"
       }
       JSON.parse(result, symbolize_names: true).map { |h| h[:wikiname] }.reject { |n| n.to_s.empty? }
     end

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = "0.16.0"
+    VERSION = "0.17.0"
   end
 end


### PR DESCRIPTION
Rather than assuming that the column we want to look up values from in a
morph scraper will always be 'data', allow a `table` parameter to supply
another (e.g for https://morph.io/davewhiteland/thailand-national-assembly)