### PR TITLE
Allow specifying lang order independently of names

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -67,10 +67,16 @@ module EveryPolitician
     require 'scraperwiki'
 
     def self.scrape_wikidata(h)
-      langs = ((h[:lang] || (h[:names] ||= {}).keys) + [:en]).flatten.uniq
-      langpairs = h[:names].map { |lang, names| WikiData.ids_from_pages(lang.to_s, names) }
-      combined  = langpairs.reduce({}) { |h, people| h.merge(people.invert) }
-      (h[:ids] ||= []).each { |id| combined[id] ||= nil }
+      h[:names] ||= {}
+      langs = ((h[:lang_precedence] || h[:names].keys) + [:en]).flatten.uniq
+      combined =
+        if h[:names].empty?
+          {}
+        else
+          lang_pairs = h[:names].map { |lang, names| WikiData.ids_from_pages(lang.to_s, names).invert }
+          lang_pairs.reduce({}) { |h, people| h.merge(people) }
+        end
+      (h[:ids] || []).each { |id| combined[id] ||= nil }
       # Clean out existing data
       ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
 
@@ -225,7 +231,7 @@ class WikiData
       @@want = lookup['want']
     end
 
-    def data(*lang)
+    def data(*langs)
       return unless @wd
 
       data = { 
@@ -237,7 +243,7 @@ class WikiData
         data["name__#{k.tr('-','_')}".to_sym] = v['value'].sub(/ \(.*?\)$/,'')
       end
 
-      data[:name] = [lang, 'en'].flatten.map { |l| data["name__#{l}".to_sym] }.compact.first
+      data[:name] = [langs, 'en'].flatten.map { |l| data["name__#{l}".to_sym] }.compact.first
 
       @wd.sitelinks.each do |k, v|
         data["wikipedia__#{k.sub(/wiki$/,'')}".to_sym] = v.title


### PR DESCRIPTION
This moves a few things around in `scrape_wikidata` to make it possible
to use the `lang` parameter (renamed `lang_precedence`) when passing a
list of `ids` and no `names` hash.  Creating the `names` hash would've
been shadowed by a non-nil `lang` on line 70.
