### PR TITLE
Update code for string-to-symbol changes in wikisnakker

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -234,13 +234,13 @@ class WikiData
 
       @wd.labels.each do |k, v|
         # remove any bracketed element at the end
-        data["name__#{k.tr('-','_')}".to_sym] = v['value'].sub(/ \(.*?\)$/,'')
+        data["name__#{k.to_s.tr('-','_')}".to_sym] = v[:value].sub(/ \(.*?\)$/,'')
       end
 
       data[:name] = [lang, 'en'].flatten.map { |l| data["name__#{l}".to_sym] }.compact.first
 
       @wd.sitelinks.each do |k, v|
-        data["wikipedia__#{k.sub(/wiki$/,'')}".to_sym] = v.title
+        data["wikipedia__#{k.to_s.sub(/wiki$/,'')}".to_sym] = v.title
       end
 
       # Short-circuit if there are no claims

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -220,9 +220,11 @@ class WikiData
 
     LOOKUP_FILE = 'https://raw.githubusercontent.com/everypolitician/wikidata-fetcher/master/lookup.json'
     def load_lookup_data!
-      lookup = JSON.load(open(LOOKUP_FILE))
-      @@skip = lookup['skip']
-      @@want = lookup['want']
+      lookup = JSON.load(
+        open(LOOKUP_FILE), nil, symbolize_names: true, create_additions: false
+      )
+      @@skip = lookup[:skip]
+      @@want = lookup[:want]
     end
 
     def data(*lang)


### PR DESCRIPTION
In everypolitician/wikisnakker@3cdf74c1 the keys used in many hashes
returned by wikisnakker were switched to symbols. This commit updates
two places where wikidata-fetcher was still expecting keys to be
strings.