### PR TITLE
Make sure non-human items are properly skipped

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -89,6 +89,7 @@ module EveryPolitician
             warn "Problem with #{id}: #{e}"
             next
           end
+          next unless data
 
           data[:original_wikiname] = name
           puts data if h[:output] == true


### PR DESCRIPTION
Fetcher.data sometimes returns nil if it encounters an item which
isn't an instance of a class with type 'human'; the error message
in this situation says "Skipping", but the way a nil return value
is handled means that the scraper aborts with an exception.

This commit changes the behaviour of the calling code, so that
when Fetcher.data returns nil, it carries on to the next item.