### PR TITLE
0.18.1 Fix Hash iteration bug in WikiData.ids_from_pages

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -118,8 +118,8 @@ class WikiData
       }
       response = client.action :query, page_args
       redirected_from = Hash[(response.data['redirects'] || []).map { |h| [h['to'], h['from']] }]
-      response.data['pages'].select { |p| p.last.key? 'pageprops' }.map do |p|
-        [redirected_from[p.last['title']] || p.last['title'], p.last['pageprops']['wikibase_item']]
+      response.data['pages'].select { |_k, v| v.key? 'pageprops' }.map do |_k, v|
+        [redirected_from[v['title']] || v['title'], v['pageprops']['wikibase_item']]
       end
     end
     results = Hash[res.flatten(1)]

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = '0.18.0'.freeze
+    VERSION = '0.18.1'.freeze
   end
 end


### PR DESCRIPTION
Sometimes, when running this, we were getting errors like:
undefined method `last' for "645976":String (NoMethodError)

I'm not entirely sure why this is breaking in some circumstances and not
others, but it’s generally better to iterate over a Hash explicitly by a
key/value combo than a pair on which we call `.first` or `.last`