### PR TITLE
Use the Rakefile to control which tasks are run on Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ mkmf.log
 *.swp
 
 *.cache
+.rubocop-https---raw-githubusercontent-com-everypolitician-everypolitician-data-master--rubocop-base-yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: ruby
-script:
-  - bundle exec rake test rubocop
 rvm:
   - 2.3.1
   - 2.2

--- a/Rakefile
+++ b/Rakefile
@@ -10,3 +10,5 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.test_files = FileList['t/*.rb']
 end
+
+task default: %i(test rubocop)


### PR DESCRIPTION
This change moves the list of tasks that are run on Travis into the `:default` rake target. This means that when you're developing locally running `bundle exec rake` will run the exact same scripts that Travis will, making it harder to accidentally break the build.

Part of https://github.com/everypolitician/everypolitician/issues/516