### PR TITLE
Don't load lookup.json for each person

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -7,8 +7,14 @@ require_rel '..'
 
 class WikiData
   class Fetcher < WikiData
+    LOOKUP_FILE = 'https://raw.githubusercontent.com/everypolitician/wikidata-fetcher/master/lookup.json'.freeze
+
     def self.find(ids)
       Hash[Wikisnakker::Item.find(ids).map { |item| [item.id, new(item: item)] }]
+    end
+
+    def self.lookup
+      @lookup ||= JSON.parse(open(LOOKUP_FILE).read, symbolize_names: true)
     end
 
     def initialize(h)
@@ -23,16 +29,8 @@ class WikiData
       else
         raise 'No id'
       end
-      load_lookup_data!
-    end
-
-    LOOKUP_FILE = 'https://raw.githubusercontent.com/everypolitician/wikidata-fetcher/master/lookup.json'.freeze
-    def load_lookup_data!
-      lookup = JSON.load(
-        open(LOOKUP_FILE), nil, symbolize_names: true, create_additions: false
-      )
-      @@skip = lookup[:skip]
-      @@want = lookup[:want]
+      @@skip = self.class.lookup[:skip]
+      @@want = self.class.lookup[:want]
     end
 
     def data(*lang)

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -29,8 +29,6 @@ class WikiData
       else
         raise 'No id'
       end
-      @@skip = self.class.lookup[:skip]
-      @@want = self.class.lookup[:want]
     end
 
     def data(*lang)
@@ -61,11 +59,11 @@ class WikiData
         return nil
       end
 
-      @wd.properties.reject { |c| @@skip[c] || @@want[c] }.each do |c|
+      @wd.properties.reject { |c| skip[c] || want[c] }.each do |c|
         puts "⁇ Unknown claim: https://www.wikidata.org/wiki/Property:#{c} for #{@wd.id}"
       end
 
-      @@want.each do |property, how|
+      want.each do |property, how|
         d = @wd[property] or next
         val = d.value rescue nil or next warn "Unknown value for #{property} for #{data[:id]}"
         data[how.to_sym] = val.respond_to?(:label) ? val.label('en') : val
@@ -73,6 +71,16 @@ class WikiData
       end
 
       data
+    end
+
+    private
+
+    def skip
+      @skip ||= self.class.lookup[:skip]
+    end
+
+    def want
+      @want ||= self.class.lookup[:want]
     end
   end
 end

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -13,8 +13,8 @@ class WikiData
       Hash[Wikisnakker::Item.find(ids).map { |item| [item.id, new(item: item)] }]
     end
 
-    def self.lookup
-      @lookup ||= JSON.parse(open(LOOKUP_FILE).read, symbolize_names: true)
+    def self.wikidata_properties
+      @wikidata_properties ||= JSON.parse(open(LOOKUP_FILE).read, symbolize_names: true)
     end
 
     def initialize(h)
@@ -73,11 +73,11 @@ class WikiData
     private
 
     def skip
-      @skip ||= self.class.lookup[:skip]
+      @skip ||= self.class.wikidata_properties[:skip]
     end
 
     def want
-      @want ||= self.class.lookup[:want]
+      @want ||= self.class.wikidata_properties[:want]
     end
   end
 


### PR DESCRIPTION
The `Fetcher` class is instantiated for each person that we want to
lookup data for, which meant that previously we were making an http
request to fetch lookup.json for every person.

This change makes it so that the lookup is at the class level, so is
only fetched on the first call and then cached for subsequent calls.

Fixes https://github.com/everypolitician/wikidata-fetcher/issues/33