### PR TITLE
0.19.1: add Wikisnakker as pre-requisite

### DIFF
--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = '0.19.0'.freeze
+    VERSION = '0.19.1'.freeze
   end
 end

--- a/wikidata-fetcher.gemspec
+++ b/wikidata-fetcher.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rest-client'
   spec.add_dependency 'scraperwiki'
   spec.add_dependency 'nokogiri'
+  spec.add_dependency 'wikisnakker'
 
   spec.add_development_dependency 'bundler', '~> 1.6'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
We use Wikisnakker internally, but didn't have it in the gemspec.