### PR TITLE
Make sure VCR dependency is at least 3.0.3

### DIFF
--- a/wikidata-fetcher.gemspec
+++ b/wikidata-fetcher.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'rubocop', '~> 0.42.0'
-  spec.add_development_dependency 'vcr', '~> 3.0.0'
+  spec.add_development_dependency 'vcr', '~> 3.0.3'
   spec.add_development_dependency 'webmock', '~> 1.22.2'
   spec.add_development_dependency 'minitest-around', '~> 0.3.2'
 end


### PR DESCRIPTION
Versions of VCR before this version didn't support webmock 2, so we want to make sure that developers always install a compatible version of VCR.

Part of https://github.com/everypolitician/everypolitician/issues/583