### PR TITLE
Do not overwrite direct link titles with redirecting titles

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.21.0  2017-07-15
+  - Ensure that `ids_from_pages` includes the correct data when multiple
+    links on a page all redirect to the same base page.
+
 0.20.2  2017-05-15
   - Ensure that preference orders passed to `data` are reflected
 

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = '0.20.2'.freeze
+    VERSION = '0.21.0'.freeze
   end
 end

--- a/t/ids_from_pages.rb
+++ b/t/ids_from_pages.rb
@@ -62,6 +62,10 @@ describe 'Wikidata#ids_from_pages' do
         subject['Wikkit Gate'].must_equal 'Q259299'
         subject['Infinite Improbability Drive'].must_equal 'Q259299'
       end
+
+      it 'knows the redirected-to page ID' do
+        subject["Technology in The Hitchhiker's Guide to the Galaxy"].must_equal 'Q259299'
+      end
     end
   end
 end

--- a/t/ids_from_pages.rb
+++ b/t/ids_from_pages.rb
@@ -27,4 +27,40 @@ describe 'Wikidata#ids_from_pages' do
       end
     end
   end
+
+  describe 'Redirect links' do
+    describe 'single redirect link' do
+      let(:titles) { ['The Deeper Meaning of Liff'] }
+
+      it 'pairs link with wikidata ID' do
+        subject.must_equal('The Deeper Meaning of Liff' => 'Q875382')
+      end
+    end
+
+    describe 'single redirect and single direct link' do
+      let(:titles) { ['The Deeper Meaning of Liff', 'The Meaning of Liff'] }
+
+      it 'pairs both redirecting link and direct link with wikidata ID' do
+        subject.must_equal('The Deeper Meaning of Liff' => 'Q875382', 'The Meaning of Liff' => 'Q875382')
+      end
+    end
+
+    describe 'multiple redirect links' do
+      let(:titles) { ['The Deeper Meaning of Liff', 'Marvin the Paranoid Android'] }
+
+      it 'returns wikidata ids paired with redirecting links and direct links' do
+        subject.must_equal('The Deeper Meaning of Liff'  => 'Q875382',
+                           'Marvin the Paranoid Android' => 'Q264685')
+      end
+    end
+
+    describe 'multiple links redirecting to the same article' do
+      let(:titles) { ['Wikkit Gate', 'Infinite Improbability Drive'] }
+
+      it 'returns wikidata ids paired with redirecting links and direct links' do
+        subject.must_equal('Wikkit Gate'                  => 'Q259299',
+                           'Infinite Improbability Drive' => 'Q259299')
+      end
+    end
+  end
 end

--- a/t/ids_from_pages.rb
+++ b/t/ids_from_pages.rb
@@ -33,7 +33,7 @@ describe 'Wikidata#ids_from_pages' do
       let(:titles) { ['The Deeper Meaning of Liff'] }
 
       it 'pairs link with wikidata ID' do
-        subject.must_equal('The Deeper Meaning of Liff' => 'Q875382')
+        subject['The Deeper Meaning of Liff'].must_equal 'Q875382'
       end
     end
 
@@ -41,7 +41,8 @@ describe 'Wikidata#ids_from_pages' do
       let(:titles) { ['The Deeper Meaning of Liff', 'The Meaning of Liff'] }
 
       it 'pairs both redirecting link and direct link with wikidata ID' do
-        subject.must_equal('The Deeper Meaning of Liff' => 'Q875382', 'The Meaning of Liff' => 'Q875382')
+        subject['The Deeper Meaning of Liff'].must_equal 'Q875382'
+        subject['The Meaning of Liff'].must_equal 'Q875382'
       end
     end
 
@@ -49,8 +50,8 @@ describe 'Wikidata#ids_from_pages' do
       let(:titles) { ['The Deeper Meaning of Liff', 'Marvin the Paranoid Android'] }
 
       it 'returns wikidata ids paired with redirecting links and direct links' do
-        subject.must_equal('The Deeper Meaning of Liff'  => 'Q875382',
-                           'Marvin the Paranoid Android' => 'Q264685')
+        subject['The Deeper Meaning of Liff'].must_equal 'Q875382'
+        subject['Marvin the Paranoid Android'].must_equal 'Q264685'
       end
     end
 
@@ -58,8 +59,8 @@ describe 'Wikidata#ids_from_pages' do
       let(:titles) { ['Wikkit Gate', 'Infinite Improbability Drive'] }
 
       it 'returns wikidata ids paired with redirecting links and direct links' do
-        subject.must_equal('Wikkit Gate'                  => 'Q259299',
-                           'Infinite Improbability Drive' => 'Q259299')
+        subject['Wikkit Gate'].must_equal 'Q259299'
+        subject['Infinite Improbability Drive'].must_equal 'Q259299'
       end
     end
   end

--- a/test/vcr_cassettes/The_Deeper_Meaning_of_Liff.yml
+++ b/test/vcr_cassettes/The_Deeper_Meaning_of_Liff.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://en.wikipedia.org/w/api.php
+    body:
+      encoding: UTF-8
+      string: action=query&format=json&ppprop=wikibase_item&prop=pageprops&redirects=1&titles=The+Deeper+Meaning+of+Liff
+    headers:
+      User-Agent:
+      - Faraday v0.12.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 25 Apr 2017 15:44:39 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '168'
+      Connection:
+      - keep-alive
+      Server:
+      - mw2127.codfw.wmnet
+      X-Powered-By:
+      - HHVM/3.12.14
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See https://en.wikipedia.org/wiki/Special:CentralAutoLogin/P3P
+        for more info."
+      X-Frame-Options:
+      - SAMEORIGIN
+      Vary:
+      - Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization
+      Backend-Timing:
+      - D=27076 t=1493135079236185
+      X-Varnish:
+      - 135480866, 729753807, 881557842
+      Via:
+      - 1.1 varnish-v4, 1.1 varnish-v4, 1.1 varnish-v4
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      X-Cache:
+      - cp2007 pass, cp3041 pass, cp3041 pass
+      X-Cache-Status:
+      - pass
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Set-Cookie:
+      - GeoIP=GB:ENG:Bristol:51.45:-2.58:v4; Path=/; secure; Domain=.wikipedia.org
+      - WMF-Last-Access-Global=25-Apr-2017;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat,
+        27 May 2017 12:00:00 GMT
+      - WMF-Last-Access=25-Apr-2017;Path=/;HttpOnly;secure;Expires=Sat, 27 May 2017
+        12:00:00 GMT
+      X-Analytics:
+      - ns=-1;special=Badtitle;https=1;nocookies=1
+      X-Client-Ip:
+      - 5.148.47.8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"redirects":[{"from":"The Deeper Meaning
+        of Liff","to":"The Meaning of Liff"}],"pages":{"79907":{"pageid":79907,"ns":0,"title":"The
+        Meaning of Liff","pageprops":{"wikibase_item":"Q875382"}}}}}'
+    http_version: 
+  recorded_at: Tue, 25 Apr 2017 15:44:39 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/The_Deeper_Meaning_of_Liff__and__Marvin_the_Paranoid_Android.yml
+++ b/test/vcr_cassettes/The_Deeper_Meaning_of_Liff__and__Marvin_the_Paranoid_Android.yml
@@ -1,0 +1,80 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://en.wikipedia.org/w/api.php
+    body:
+      encoding: UTF-8
+      string: action=query&format=json&ppprop=wikibase_item&prop=pageprops&redirects=1&titles=The+Deeper+Meaning+of+Liff%7CMarvin+the+Paranoid+Android
+    headers:
+      User-Agent:
+      - Faraday v0.12.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 25 Apr 2017 15:47:11 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '234'
+      Connection:
+      - keep-alive
+      Server:
+      - mw2210.codfw.wmnet
+      X-Powered-By:
+      - HHVM/3.12.14
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See https://en.wikipedia.org/wiki/Special:CentralAutoLogin/P3P
+        for more info."
+      X-Frame-Options:
+      - SAMEORIGIN
+      Vary:
+      - Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization
+      Backend-Timing:
+      - D=25482 t=1493135231684442
+      X-Varnish:
+      - 559358415, 139601695, 881333170
+      Via:
+      - 1.1 varnish-v4, 1.1 varnish-v4, 1.1 varnish-v4
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      X-Cache:
+      - cp2001 pass, cp3033 pass, cp3041 pass
+      X-Cache-Status:
+      - pass
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Set-Cookie:
+      - GeoIP=GB:ENG:Bristol:51.45:-2.58:v4; Path=/; secure; Domain=.wikipedia.org
+      - WMF-Last-Access-Global=25-Apr-2017;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat,
+        27 May 2017 12:00:00 GMT
+      - WMF-Last-Access=25-Apr-2017;Path=/;HttpOnly;secure;Expires=Sat, 27 May 2017
+        12:00:00 GMT
+      X-Analytics:
+      - ns=-1;special=Badtitle;https=1;nocookies=1
+      X-Client-Ip:
+      - 5.148.47.8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"redirects":[{"from":"The Deeper Meaning
+        of Liff","to":"The Meaning of Liff"},{"from":"Marvin the Paranoid Android","to":"Marvin
+        (character)"}],"pages":{"159973":{"pageid":159973,"ns":0,"title":"Marvin (character)","pageprops":{"wikibase_item":"Q264685"}},"79907":{"pageid":79907,"ns":0,"title":"The
+        Meaning of Liff","pageprops":{"wikibase_item":"Q875382"}}}}}'
+    http_version: 
+  recorded_at: Tue, 25 Apr 2017 15:47:11 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/The_Deeper_Meaning_of_Liff__and__The_Meaning_of_Liff.yml
+++ b/test/vcr_cassettes/The_Deeper_Meaning_of_Liff__and__The_Meaning_of_Liff.yml
@@ -1,0 +1,79 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://en.wikipedia.org/w/api.php
+    body:
+      encoding: UTF-8
+      string: action=query&format=json&ppprop=wikibase_item&prop=pageprops&redirects=1&titles=The+Deeper+Meaning+of+Liff%7CThe+Meaning+of+Liff
+    headers:
+      User-Agent:
+      - Faraday v0.12.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 25 Apr 2017 15:47:12 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '168'
+      Connection:
+      - keep-alive
+      Server:
+      - mw2129.codfw.wmnet
+      X-Powered-By:
+      - HHVM/3.12.14
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See https://en.wikipedia.org/wiki/Special:CentralAutoLogin/P3P
+        for more info."
+      X-Frame-Options:
+      - SAMEORIGIN
+      Vary:
+      - Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization
+      Backend-Timing:
+      - D=36526 t=1493135231977171
+      X-Varnish:
+      - 226582138, 111933777, 878137114
+      Via:
+      - 1.1 varnish-v4, 1.1 varnish-v4, 1.1 varnish-v4
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      X-Cache:
+      - cp2013 pass, cp3033 pass, cp3041 pass
+      X-Cache-Status:
+      - pass
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Set-Cookie:
+      - GeoIP=GB:ENG:Bristol:51.45:-2.58:v4; Path=/; secure; Domain=.wikipedia.org
+      - WMF-Last-Access-Global=25-Apr-2017;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat,
+        27 May 2017 12:00:00 GMT
+      - WMF-Last-Access=25-Apr-2017;Path=/;HttpOnly;secure;Expires=Sat, 27 May 2017
+        12:00:00 GMT
+      X-Analytics:
+      - ns=-1;special=Badtitle;https=1;nocookies=1
+      X-Client-Ip:
+      - 5.148.47.8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"redirects":[{"from":"The Deeper Meaning
+        of Liff","to":"The Meaning of Liff"}],"pages":{"79907":{"pageid":79907,"ns":0,"title":"The
+        Meaning of Liff","pageprops":{"wikibase_item":"Q875382"}}}}}'
+    http_version: 
+  recorded_at: Tue, 25 Apr 2017 15:47:12 GMT
+recorded_with: VCR 3.0.3

--- a/test/vcr_cassettes/Wikkit_Gate__and__Infinite_Improbability_Drive.yml
+++ b/test/vcr_cassettes/Wikkit_Gate__and__Infinite_Improbability_Drive.yml
@@ -1,0 +1,81 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://en.wikipedia.org/w/api.php
+    body:
+      encoding: UTF-8
+      string: action=query&format=json&ppprop=wikibase_item&prop=pageprops&redirects=1&titles=Wikkit+Gate%7CInfinite+Improbability+Drive
+    headers:
+      User-Agent:
+      - Faraday v0.12.1
+      Content-Type:
+      - application/x-www-form-urlencoded
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 25 Apr 2017 15:47:13 GMT
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '238'
+      Connection:
+      - keep-alive
+      Server:
+      - mw2139.codfw.wmnet
+      X-Powered-By:
+      - HHVM/3.12.14
+      X-Content-Type-Options:
+      - nosniff
+      Cache-Control:
+      - private, must-revalidate, max-age=0
+      P3p:
+      - CP="This is not a P3P policy! See https://en.wikipedia.org/wiki/Special:CentralAutoLogin/P3P
+        for more info."
+      X-Frame-Options:
+      - SAMEORIGIN
+      Vary:
+      - Accept-Encoding,Treat-as-Untrusted,X-Forwarded-Proto,Cookie,Authorization
+      Backend-Timing:
+      - D=51486 t=1493135233116423
+      X-Varnish:
+      - 119325544, 867337965, 882085110
+      Via:
+      - 1.1 varnish-v4, 1.1 varnish-v4, 1.1 varnish-v4
+      Accept-Ranges:
+      - bytes
+      Age:
+      - '0'
+      X-Cache:
+      - cp2007 pass, cp3030 pass, cp3041 pass
+      X-Cache-Status:
+      - pass
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Set-Cookie:
+      - GeoIP=GB:ENG:Bristol:51.45:-2.58:v4; Path=/; secure; Domain=.wikipedia.org
+      - WMF-Last-Access-Global=25-Apr-2017;Path=/;Domain=.wikipedia.org;HttpOnly;secure;Expires=Sat,
+        27 May 2017 12:00:00 GMT
+      - WMF-Last-Access=25-Apr-2017;Path=/;HttpOnly;secure;Expires=Sat, 27 May 2017
+        12:00:00 GMT
+      X-Analytics:
+      - ns=-1;special=Badtitle;https=1;nocookies=1
+      X-Client-Ip:
+      - 5.148.47.8
+    body:
+      encoding: ASCII-8BIT
+      string: '{"batchcomplete":"","query":{"redirects":[{"from":"Infinite Improbability
+        Drive","to":"Technology in The Hitchhiker''s Guide to the Galaxy","tofragment":"Infinite
+        Improbability Drive"},{"from":"Wikkit Gate","to":"Technology in The Hitchhiker''s
+        Guide to the Galaxy","tofragment":"Wikkit gate"}],"pages":{"19728139":{"pageid":19728139,"ns":0,"title":"Technology
+        in The Hitchhiker''s Guide to the Galaxy","pageprops":{"wikibase_item":"Q259299"}}}}}'
+    http_version: 
+  recorded_at: Tue, 25 Apr 2017 15:47:13 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Fixes: https://github.com/everypolitician/wikidata-fetcher/issues/44 and https://github.com/everypolitician/wikidata-fetcher/issues/46

The wikipedia page for 'The Deeper Meaning of Liff' redirects to 'The Meaning of Life'.

`WikiData.ids_from_pages('en', ['The Meaning of Liff', 'The Deeper Meaning of Liff'])` currently only returns:

```{'The Deeper Meaning of Liff' => 'Q875382'}```

No wikidata ID is returned of 'The Meaning of Liff'.

This commit returns the wikidata id with both links:
```
{ 'The Meaning of Liff' => 'Q875382', 'The Deeper Meaning of Liff' => 'Q875382' }
```