### PR TITLE
0.19.2 (bugfix): Allow languages to be specified as an array

### DIFF
--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -110,7 +110,7 @@ class WikiData
     end
 
     def first_label_used(language_codes)
-      prefered = (item.labels.keys & language_codes.map(&:to_sym)).first or return
+      prefered = (item.labels.keys & language_codes.flatten.map(&:to_sym)).first or return
       item.labels[prefered][:value]
     end
   end

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = '0.19.1'.freeze
+    VERSION = '0.19.2'.freeze
   end
 end

--- a/t/data.rb
+++ b/t/data.rb
@@ -50,7 +50,7 @@ describe 'Kadri Simpson' do
   end
 
   it 'can fetch multiple names' do
-    data = subject.data('en', 'et')
+    data = subject.data(%w(en et))
     data[:name__et].must_equal 'Kadri Simson'
     data[:name__en].must_equal 'Kadri Simson'
     data[:name].must_equal 'Kadri Simson'
@@ -62,7 +62,7 @@ describe 'Kadri Simpson' do
   end
 
   it 'knows multiple wikipedia pages' do
-    data = subject.data('en', 'et')
+    data = subject.data(%i(en et))
     data[:wikipedia__et].must_equal 'Kadri Simson'
     data[:wikipedia__en].must_equal 'Kadri Simson'
   end


### PR DESCRIPTION
When passing the languages we prefer to the `data` method, ensure that we
can pass either a list of individual entries, or an array.