### PR TITLE
Release 0.20.1: When caclculating best 'name' used pre-processed labels

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.20.1  2017-05-15
+  - Ensure that bracketed parts are stripped from 'name', not just
+    aliases.
+
 0.20.0  2017-04-25
   - Extract account names for various websites in P553
 

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -127,7 +127,7 @@ class WikiData
 
     def first_label_used(language_codes)
       prefered = (item.labels.keys & language_codes.flatten.map(&:to_sym)).first or return
-      item.labels[prefered][:value]
+      labels["name__#{prefered}".to_sym]
     end
   end
 end

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = '0.20.0'.freeze
+    VERSION = '0.20.1'.freeze
   end
 end

--- a/t/data.rb
+++ b/t/data.rb
@@ -21,6 +21,19 @@ describe 'data' do
   end
 end
 
+describe 'bracketed names' do
+  around { |test| VCR.use_cassette('Picard', &test) }
+  subject { WikiData::Fetcher.new(id: 'Q21178739').data }
+
+  it 'should know its ID' do
+    subject[:id].must_equal 'Q21178739'
+  end
+
+  it 'should strip brackets from names' do
+    subject[:name].must_equal 'Michel Picard'
+  end
+end
+
 describe 'non-English' do
   around { |test| VCR.use_cassette('Bierasniewa', &test) }
   subject { WikiData::Fetcher.new(id: 'Q14917860') }


### PR DESCRIPTION
Ensure that `name`, not just the other-language-aliases, have the bracketed sections stripped from the end.
