### PR TITLE
0.20.2 Bugfix: Ensure that names are preferred correctly

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,6 @@
+0.20.2  2017-05-15
+  - Ensure that preference orders passed to `data` are reflected
+
 0.20.1  2017-05-15
   - Ensure that bracketed parts are stripped from 'name', not just
     aliases.

--- a/lib/wikidata/fetcher.rb
+++ b/lib/wikidata/fetcher.rb
@@ -126,7 +126,7 @@ class WikiData
     end
 
     def first_label_used(language_codes)
-      prefered = (item.labels.keys & language_codes.flatten.map(&:to_sym)).first or return
+      prefered = (language_codes.flatten.map(&:to_sym) & item.labels.keys).first or return
       labels["name__#{prefered}".to_sym]
     end
   end

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -1,5 +1,5 @@
 module Wikidata
   module Fetcher
-    VERSION = '0.20.1'.freeze
+    VERSION = '0.20.2'.freeze
   end
 end

--- a/t/data.rb
+++ b/t/data.rb
@@ -21,6 +21,44 @@ describe 'data' do
   end
 end
 
+describe 'data preferences' do
+  around { |test| VCR.use_cassette('Parts', &test) }
+  subject { WikiData::Fetcher.new(id: 'Q312894').data(:be) }
+
+  it 'can prefer Estonian' do
+    data = WikiData::Fetcher.new(id: 'Q312894').data(%i(et be))
+    data[:name].must_equal 'Juhan Parts'
+  end
+
+  it 'can prefer Belarussian' do
+    data = WikiData::Fetcher.new(id: 'Q312894').data(%i(be et))
+    data[:name].must_equal 'Юган Партс'
+  end
+
+  it 'can fall back on second preference' do
+    data = WikiData::Fetcher.new(id: 'Q312894').data(%i(se be et))
+    data[:name__se].must_be_nil
+    data[:name].must_equal 'Юган Партс'
+  end
+
+  it 'falls back on English if no suitable language' do
+    data = WikiData::Fetcher.new(id: 'Q312894').data(%i(se si))
+    data[:name__se].must_be_nil
+    data[:name__si].must_be_nil
+    data[:name].must_equal 'Juhan Parts'
+  end
+
+  it 'can take a single string' do
+    data = WikiData::Fetcher.new(id: 'Q312894').data('lv')
+    data[:name].must_equal 'Juhans Partss'
+  end
+
+  it 'can take a single symbol' do
+    data = WikiData::Fetcher.new(id: 'Q312894').data(:lv)
+    data[:name].must_equal 'Juhans Partss'
+  end
+end
+
 describe 'bracketed names' do
   around { |test| VCR.use_cassette('Picard', &test) }
   subject { WikiData::Fetcher.new(id: 'Q21178739').data }


### PR DESCRIPTION
Giving a list of preferences to `data` should prefer names in the order
given.