### PR TITLE
0.23 obsolete notify_rebuilder and wdq methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,6 @@ before_install:
   - gem update --system --no-doc
   - gem install bundler -v 1.14.1
 rvm:
-  - 2.3.1
-  - 2.2
-  - 2.1
+  - 2.3
+  - 2.4
+  - 2.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: ruby
 cache: bundler
 before_install:
   - gem update --system --no-doc
-  - gem install bundler -v 1.14.1
 rvm:
   - 2.3
   - 2.4

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.23.0  2019-02-04
+  - remove obsolete `notify_rebuilder` and `wdq` methods
+  - minimum supported ruby version is now 2.3
+
 0.22.0  2018-10-10
   - convert results of Wikipedia scraping to Wikidata IDs if requested
 

--- a/README.md
+++ b/README.md
@@ -43,18 +43,10 @@ EveryPolitician::Wikidata.scrape_wikidata(names: { en: names })
 
 # NB: this can take multiple lists, and can also output the data as it fetches it:
 
-EveryPolitician::Wikidata.scrape_wikidata(names: { 
+EveryPolitician::Wikidata.scrape_wikidata(names: {
   es: es_names,
   en: en_names,
 }, output: true)
-
-#-----------------------------
-# Step 3: Notify the Rebuilder
-#-----------------------------
-
-EveryPolitician::Wikidata.notify_rebuilder
-
-(This requires MORPH_REBUILDER_URL to be set in the environment)
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,9 +32,6 @@ names = EveryPolitician::Wikidata.morph_wikinames(source: 'tmtmtmtm/tuvalu-parli
 # or from a SPARQL query
 ids = EveryPolitician::Wikidata.sparql('SELECT ?item WHERE { ?item wdt:P39 wd:Q18229570 . }')
 
-# or from a WDQ query
-ids = EveryPolitician::Wikidata.wdq('claim[463:21124329]')
-
 #-----------------------------------------------------------
 # Step 2: Scrape the data from Wikidata based on these names
 #-----------------------------------------------------------

--- a/lib/wikidata.rb
+++ b/lib/wikidata.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'colorize'
 require 'digest/sha1'
 require 'json'
 require 'mediawiki_api'

--- a/lib/wikidata.rb
+++ b/lib/wikidata.rb
@@ -161,13 +161,5 @@ module EveryPolitician
         end
       end
     end
-
-    #-------------------------------------------------------------------
-
-    require 'rest-client'
-
-    def self.notify_rebuilder
-      RestClient.post ENV['MORPH_REBUILDER_URL'], {} if ENV['MORPH_REBUILDER_URL']
-    end
   end
 end

--- a/lib/wikidata.rb
+++ b/lib/wikidata.rb
@@ -56,14 +56,6 @@ end
 
 module EveryPolitician
   module Wikidata
-    WDQ_URL = 'https://wdq.wmflabs.org/api'
-
-    def self.wdq(query)
-      result = RestClient.get WDQ_URL, params: { q: query }
-      json = JSON.parse(result, symbolize_names: true)
-      json[:items].map { |id| "Q#{id}" }
-    end
-
     WIKIDATA_SPARQL_URL = 'https://query.wikidata.org/sparql'
 
     def self.sparql(query)

--- a/lib/wikidata/fetcher/version.rb
+++ b/lib/wikidata/fetcher/version.rb
@@ -2,6 +2,6 @@
 
 module Wikidata
   module Fetcher
-    VERSION = '0.22.0'
+    VERSION = '0.23.0'
   end
 end

--- a/wikidata-fetcher.gemspec
+++ b/wikidata-fetcher.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'wikidata-client', '~> 0.0.7'
   spec.add_dependency 'wikisnakker'
 
-  spec.add_development_dependency 'bundler', '~> 1.6'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-around'
   spec.add_development_dependency 'pry'

--- a/wikidata-fetcher.gemspec
+++ b/wikidata-fetcher.gemspec
@@ -19,8 +19,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'colorize'
-  spec.add_dependency 'diskcached'
   spec.add_dependency 'json'
   spec.add_dependency 'mediawiki_api'
   spec.add_dependency 'nokogiri'

--- a/wikidata-fetcher.gemspec
+++ b/wikidata-fetcher.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
+  spec.required_ruby_version = '>= 2.3.0'
+
   spec.add_dependency 'json'
   spec.add_dependency 'mediawiki_api'
   spec.add_dependency 'nokogiri'


### PR DESCRIPTION
These haven't been needed/used/available for quite some time.